### PR TITLE
fix: 优化已有对应文案处理

### DIFF
--- a/src/utils/addFomatMessage.ts
+++ b/src/utils/addFomatMessage.ts
@@ -5,6 +5,7 @@ import { getNewKey } from "./extra";
 import { isInsideArguments } from "./isInsideArguments";
 import allowUseHook from "./allowUseHook";
 import { replaceTemplateElement } from "./TemplateElement";
+import { getSpaces, getText } from "./getText";
 
 function createFormat(
   text: string,
@@ -42,13 +43,12 @@ function replaceText(
     localeKey: string | undefined;
   }
 ) {
-  if (t.isJSXText(path.node)) {
-    const text = path.node.value;
-    const rawText = text.replace(/^[\n\s]*/, "").replace(/[\n\s]*$/, "");
-    const foreSpaces = text.match(/^[\n\s]*/)?.[0] || "";
-    const endSpaces = text.match(/[\n\s]*$/)?.[0] || "";
+  const text = getText(path);
 
-    const expression = createFormat(rawText, {
+  if (t.isJSXText(path.node)) {
+    const [foreSpaces, endSpaces] = getSpaces(path as NodePath<t.JSXText>);
+
+    const expression = createFormat(text, {
       intlKey,
       formatMessageKey,
       localeKey,
@@ -60,12 +60,9 @@ function replaceText(
       t.jsxText(endSpaces),
     ]);
   } else if (t.isTemplateElement(path.node)) {
-    const text = path.node.value.raw;
-    const rawText = text.replace(/^[\n\s]*/, "").replace(/[\n\s]*$/, "");
-    const foreSpaces = text.match(/^[\n\s]*/)?.[0] || "";
-    const endSpaces = text.match(/[\n\s]*$/)?.[0] || "";
+    const [foreSpaces, endSpaces] = getSpaces(path as NodePath<t.JSXText>);
 
-    const expression = createFormat(rawText, {
+    const expression = createFormat(text, {
       intlKey,
       formatMessageKey,
       localeKey,

--- a/src/utils/extra.ts
+++ b/src/utils/extra.ts
@@ -28,11 +28,27 @@ export function isKeyExist(key: string) {
   );
 }
 
+function getMatchByText(text: string) {
+  return Object.entries({
+    ...config.externalLocaleMap,
+    ...LocaleMap,
+  }).find(([key, value]) => {
+    if (value === text) {
+      return true;
+    }
+    return false;
+  });
+}
+
 export function getPrefixKey(key: string) {
   return `${config.localePrefix}${key}`;
 }
 
-export function getNextKey() {
+export function getNextKey(text: string) {
+  const match = getMatchByText(text);
+  if (match) {
+    return match[0];
+  }
   return config.localePrefix + (config.localeOffset + lastIndex);
 }
 
@@ -44,15 +60,7 @@ export function getNewKey(text: string, inputLocaleKey?: string) {
     return prefixedKey;
   }
 
-  const existLocale = Object.entries({
-    ...config.externalLocaleMap,
-    ...LocaleMap,
-  }).find(([key, value]) => {
-    if (value === text) {
-      return true;
-    }
-    return false;
-  });
+  const existLocale = getMatchByText(text);
 
   if (existLocale) {
     return existLocale.at(0) as string;

--- a/src/utils/getText.ts
+++ b/src/utils/getText.ts
@@ -1,0 +1,29 @@
+import { NodePath } from "@babel/traverse";
+import * as t from "@babel/types";
+
+const foreSpacesReg = /^[\n\s]*/;
+const endSpacesReg = /[\n\s]*$/;
+
+export function getText(
+  path: NodePath<t.JSXText | t.StringLiteral | t.TemplateElement>
+) {
+  if (t.isTemplateElement(path.node)) {
+    return path.node.value.raw
+      .replace(foreSpacesReg, "")
+      .replace(endSpacesReg, "");
+  }
+  if (t.isJSXText(path.node)) {
+    return path.node.value.replace(foreSpacesReg, "").replace(endSpacesReg, "");
+  }
+  return path.node.value;
+}
+
+export function getSpaces(path: NodePath<t.JSXText | t.TemplateElement>) {
+  const rawText = t.isTemplateElement(path.node)
+    ? path.node.value.raw
+    : path.node.value;
+  return [
+    rawText.match(foreSpacesReg)?.[0] || "",
+    rawText.match(endSpacesReg)?.[0] || "",
+  ];
+}


### PR DESCRIPTION
## CHANGES

- 如果文案已存在于localeMap，则默认键值设置为已存在的对应键
```js
localeMap = {
   'zh': '中文'
}

defaultKey: 'zh'
```